### PR TITLE
Jameica-Repository eingerichtet

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,12 @@
                     meinen Schulter ruht. Falls jemand Interesse hat einfach ein Issue aufmachen und ich füge
                     ihn zur <a href='https://github.com/openjverein'>openjverein organisation</a> hinzu.
 
-                    ich habe Heiner auch zu Organisation hinzugefügt, falls er sich einbringen würde wäre das super!
+                    Ich habe Heiner auch zu Organisation hinzugefügt, falls er sich einbringen würde wäre das super!
+                    
+                    Um in Jameica auf den Fork umzusteigen, das Repository <code>https://www.jverein.de/updates</code> deaktivieren oder entfernen
+                    und das Repository <code>https://openjverein.github.io/jameica-repository</code> hinzufügen.
 
-                    <a href='https://github.com/openjverein/jverein/milestone/2?closed=1'>Changelog</a>
+                    <a href='https://github.com/openjverein/jverein/milestone/1?closed=1'>Changelog</a>
                 </p>
 
                 <b>23.06.2019 www.jverein.de ist jetzt auch unter https verfügbar</b>
@@ -164,3 +167,4 @@
     <script src="https://kit.fontawesome.com/4243617752.js"></script>
 </body>
 </html>
+

--- a/jameica-repository/plugin.xml
+++ b/jameica-repository/plugin.xml
@@ -1,0 +1,45 @@
+<plugin xmlns="http://www.willuhn.de/schema/jameica-plugin"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.willuhn.de/schema/jameica-plugin http://www.willuhn.de/schema/jameica-plugin-1.2.xsd"
+        name="jverein" version="2.8.19" class="de.jost_net.JVerein.JVereinPlugin">
+
+  <description>OpenSource-Vereinsverwaltung</description>
+  <url>https://openjverein.github.io/jameica-repository/jverein.2.8.19.zip</url>
+  <homepage>https://www.jverein.de</homepage>
+  <license>GPL - http://www.gnu.org/copyleft/gpl.html</license>
+  <icon>jverein-icon-64x64.png</icon>
+  <menu>
+    <item name="JVerein" >
+  	  <item name="&amp;Über" 
+            action="de.jost_net.JVerein.gui.action.AboutAction" 
+            icon="gtk-info.png"  />
+      <item name="-" />
+      <item name="Lizenzinformationen"
+            action="de.jost_net.JVerein.gui.action.LizenzAction"
+            icon="text-x-generic.png" />
+    </item>
+  </menu>
+  <classfinder>
+    <include>jverein\.jar</include>
+    <include>.*\.class</include>
+  </classfinder>
+
+  <navigation>
+    <item name="JVerein"		
+	  icon-close="folder.png" 
+	  icon-open="folder-open.png" 	
+    id="jverein.main">
+    </item>
+  </navigation>
+   
+  <services>
+    <service name="database" depends="" autostart="true"
+	  class="de.jost_net.JVerein.server.JVereinDBServiceImpl" />
+  </services>
+	
+  <requires jameica="2.8+">
+    <import plugin="hibiscus" version="2.8.7+"/>
+  </requires>
+	
+</plugin>
+

--- a/jameica-repository/repository.xml
+++ b/jameica-repository/repository.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<repository xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://www.willuhn.de/schema/jameica-repository-1.0.xsd"
+  name="JVerein Repository">
+
+  <plugins name="JVerein">
+     <plugin url="https://openjverein.github.io/jameica-repository"/>
+  </plugins>
+</repository>
+


### PR DESCRIPTION
Wenn https://openjverein.github.io/jameica-repository in Jameica als Repository eingetragen wird, kann das Plugin in Jameica ohne manuellen Download installiert werden. Das funktioniert auch für hier veröffentlichte Updates.

Das Plugin habe ich mit hochgeladen, anstatt nur den Link zum Release in GitHub, weil der Download aus GitHub mit Jameica scheitert.